### PR TITLE
Test Implementations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 .env
 .python-version
 .pytest_cache/
+.vscode/
 reports/

--- a/connections/models/connection.py
+++ b/connections/models/connection.py
@@ -21,3 +21,6 @@ class Connection(Model, CRUDMixin, CreatedUpdatedMixin):
     from_person_id = db.Column(db.Integer, db.ForeignKey('person.id'))
     to_person_id = db.Column(db.Integer, db.ForeignKey('person.id'))
     connection_type = db.Column(db.Enum(ConnectionType), nullable=False)
+
+    from_person = db.relationship("Person", foreign_keys=from_person_id)
+    to_person = db.relationship("Person", foreign_keys=to_person_id)

--- a/connections/models/person.py
+++ b/connections/models/person.py
@@ -1,5 +1,7 @@
 from connections.database import CreatedUpdatedMixin, CRUDMixin, db, Model
 
+from connections.models.connection import ConnectionType
+
 
 class Person(Model, CRUDMixin, CreatedUpdatedMixin):
     id = db.Column(db.Integer, primary_key=True)
@@ -7,4 +9,14 @@ class Person(Model, CRUDMixin, CreatedUpdatedMixin):
     last_name = db.Column(db.String(64))
     email = db.Column(db.String(145), unique=True, nullable=False)
 
-    connections = db.relationship('Connection', foreign_keys='Connection.from_person_id')
+    connections = db.relationship(
+        'Connection', foreign_keys='Connection.from_person_id', lazy='dynamic')
+
+    def mutual_friends(self, Person):
+        self_friends = self.connections.filter_by(connection_type=ConnectionType.friend)
+        other_friends = Person.connections.filter_by(connection_type=ConnectionType.friend)
+
+        mutual_connections = self_friends.union(other_friends)
+        result = set(connection.to_person for connection in mutual_connections)
+
+        return result

--- a/connections/schemas.py
+++ b/connections/schemas.py
@@ -12,6 +12,7 @@ class BaseModelSchema(ma.ModelSchema):
 
 
 class PersonSchema(BaseModelSchema):
+    email = fields.Email()
 
     class Meta:
         model = Person

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -85,6 +85,7 @@ definitions:
         type: "string"
       email:
         type: "string"
+        format: "email"
 
   Connection:
     type: "object"


### PR DESCRIPTION
- Declare email type on Person schema for input validation
- Added mutual_friends function on Person model, passing in another Person to return all friend connections that are mutual between the Person instance and the passed in Person
- Ignore vscode meta

**Note to reviewer:** This was a great crash course on SqlAlchemy's ORM and query building. The only thing I would have done differently was spend more time trying to figure out how to use `intersect()` rather than `union()` to avoid post processing (was throwing SQL exception on a seemingly valid query), or to understand how to express an inner join. Felt like the answer was on the tip of my brain, I was probably missing something simple, but decided to move on for now.