### PR TITLE
Connection endpoints

### DIFF
--- a/connections/schemas.py
+++ b/connections/schemas.py
@@ -23,5 +23,8 @@ class ConnectionSchema(BaseModelSchema):
     to_person_id = fields.Integer()
     connection_type = EnumField(ConnectionType)
 
+    from_person = fields.Nested(PersonSchema)
+    to_person = fields.Nested(PersonSchema)
+
     class Meta:
         model = Connection

--- a/connections/schemas.py
+++ b/connections/schemas.py
@@ -28,3 +28,10 @@ class ConnectionSchema(BaseModelSchema):
 
     class Meta:
         model = Connection
+
+
+class UpdateConnectionTypeSchema(BaseModelSchema):
+    connection_type = EnumField(ConnectionType)
+
+    class Meta:
+        model = Connection

--- a/connections/views.py
+++ b/connections/views.py
@@ -4,6 +4,7 @@ from flask import Blueprint
 from webargs.flaskparser import use_args
 
 from connections.models.person import Person
+from connections.models.connection import Connection
 from connections.schemas import ConnectionSchema, PersonSchema
 
 blueprint = Blueprint('connections', __name__)
@@ -21,6 +22,13 @@ def get_people():
 def create_person(person):
     person.save()
     return PersonSchema().jsonify(person), HTTPStatus.CREATED
+
+
+@blueprint.route('/connections', methods=['GET'])
+def get_connections():
+    connection_schema = ConnectionSchema(many=True)
+    connections = Connection.query.all()
+    return connection_schema.jsonify(connections), HTTPStatus.OK
 
 
 @blueprint.route('/connections', methods=['POST'])

--- a/connections/views.py
+++ b/connections/views.py
@@ -1,11 +1,12 @@
 from http import HTTPStatus
 
-from flask import Blueprint
+from flask import Blueprint, abort
 from webargs.flaskparser import use_args
+from sqlalchemy.orm.exc import NoResultFound
 
 from connections.models.person import Person
 from connections.models.connection import Connection
-from connections.schemas import ConnectionSchema, PersonSchema
+from connections.schemas import ConnectionSchema, UpdateConnectionTypeSchema, PersonSchema
 
 blueprint = Blueprint('connections', __name__)
 
@@ -36,3 +37,14 @@ def get_connections():
 def create_connection(connection):
     connection.save()
     return ConnectionSchema().jsonify(connection), HTTPStatus.CREATED
+
+
+@blueprint.route('/connections/<connection_id>', methods=['PATCH'])
+@use_args(UpdateConnectionTypeSchema(), locations=('json',))
+def update_connection_type(request, connection_id):
+    connection = Connection.query.get(connection_id)
+    if not connection:
+        abort(404)
+
+    connection.connection_type = request.connection_type
+    return UpdateConnectionTypeSchema().jsonify(connection), HTTPStatus.OK

--- a/connections/views.py
+++ b/connections/views.py
@@ -2,7 +2,6 @@ from http import HTTPStatus
 
 from flask import Blueprint, abort
 from webargs.flaskparser import use_args
-from sqlalchemy.orm.exc import NoResultFound
 
 from connections.models.person import Person
 from connections.models.connection import Connection

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -86,6 +86,22 @@ paths:
               $ref: "#/definitions/Connection"
         400:
           description: "Invalid input"
+  /connections/{connection_id}:
+    patch:
+      summary: "Update a connection's ConnectionType"
+      operationId: "updateConnectionType"
+      consumes:
+      - "application/json"
+      produces:
+      - "application/json"
+      parameters:
+      - in: "body"
+        name: "body"
+        description: "Connection object containing connection_type field to be updated"
+        required: true
+        schema:
+          $ref: "#/definitions/Connection/properties/connection_type"
+
 definitions:
   Person:
     type: "object"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -48,6 +48,20 @@ paths:
         400:
           description: "Invalid input"
   /connections:
+    get:
+      summary: "Get list of connections"
+      operationId: "getConnections"
+      produces:
+      - "application/json"
+      responses:        
+        200:
+          description: "successful operation"
+          schema:
+            type: "array"
+            items:
+              $ref: "#/definitions/Connection"
+        400:
+          description: "Invalid input"
     post:
       summary: "Create a new connection"
       description: ""
@@ -101,6 +115,10 @@ definitions:
         type: "integer"
         format: "int64"
         description: "To Person"
+      from_person:
+        $ref: "#/definitions/Person"
+      to_person:
+        $ref: "#/definitions/Person"
       connection_type:
         type: "string"
         description: "Connection Type"

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -101,6 +101,17 @@ paths:
         required: true
         schema:
           $ref: "#/definitions/Connection/properties/connection_type"
+      responses:
+        200:
+          description: "successful operation"
+          schema:
+            type: "object"
+            items:
+              $ref: "#/definitions/Connection"
+        400:
+          description: "Invalid input"
+        404:
+          description: "Not found"
 
 definitions:
   Person:

--- a/tests/functional/connections/test_get_connections.py
+++ b/tests/functional/connections/test_get_connections.py
@@ -1,0 +1,37 @@
+from http import HTTPStatus
+
+from tests.factories import ConnectionFactory, PersonFactory
+
+EXPECTED_FIELDS = [
+    'id',
+    'from_person',
+    'to_person',
+]
+
+PEOPLE_EXPECTED_FIELDS = [
+    'id',
+    'first_name',
+    'last_name',
+    'email',
+]
+
+
+def test_can_get_connections(db, testapp):
+    personA = PersonFactory()
+    personB = PersonFactory()
+
+    ConnectionFactory.create_batch(10, from_person=personA, to_person=personB)
+
+    db.session.commit()
+
+    res = testapp.get('/connections')
+
+    assert res.status_code == HTTPStatus.OK
+
+    assert len(res.json) == 10
+    for connection in res.json:
+        for field in EXPECTED_FIELDS:
+            assert field in connection
+            for p_field in PEOPLE_EXPECTED_FIELDS:
+                assert p_field in connection['from_person']
+                assert p_field in connection['to_person']

--- a/tests/functional/connections/test_update_connection_type.py
+++ b/tests/functional/connections/test_update_connection_type.py
@@ -1,0 +1,49 @@
+from http import HTTPStatus
+
+import pytest
+
+from tests.factories import PersonFactory, ConnectionFactory
+from connections.models.connection import ConnectionType
+
+
+@pytest.fixture
+def connection_payload():
+    return {
+        'connection_type': ConnectionType.friend.value,
+    }
+
+
+def test_can_update_connection_type(db, testapp, connection_payload):
+    connection = ConnectionFactory.create(connection_type=ConnectionType.father.value)
+    db.session.commit()
+
+    res = testapp.patch('/connections/' + str(connection.id), json=connection_payload)
+
+    assert res.status_code == HTTPStatus.OK
+    assert res.json['connection_type'] == connection_payload['connection_type']
+
+
+@pytest.mark.parametrize('field, value, error_message', [
+    pytest.param('connection_type', None, 'Field may not be null.',
+                 id='missing connection type'),
+    pytest.param('connection_type', 'borke', 'Invalid enum member borke',
+                 id='invalid connection type')
+])
+def test_update_connection_type_validations(db, testapp, connection_payload, field, value, error_message):
+    connection = ConnectionFactory.create(connection_type=ConnectionType.father)
+    db.session.commit()
+
+    connection_payload[field] = value
+
+    res = testapp.patch('/connections/' + str(connection.id), json=connection_payload)
+
+    assert res.status_code == HTTPStatus.BAD_REQUEST
+    assert res.json['description'] == 'Input failed validation.'
+    errors = res.json['errors']
+    assert error_message in errors[field]
+
+
+def test_connection_not_found(db, testapp, connection_payload):
+    res = testapp.patch('/connections/123', json=connection_payload)
+
+    assert res.status_code == HTTPStatus.NOT_FOUND


### PR DESCRIPTION
- `/connections` :
  - return list of all connections, including from_person and to_person related objects
- `/connections/<connection_id>` :
  - update an existing connection's connection_type value
  - validate connection exists
  - validate connection_type field to exist and be valid ConnectionType enum value

**Note to reviewer:** I decided to create the additional UpdateConnectionTypeSchema to disallow updating other connection fields, although the handler logic explicitly updates that one field. I typically like being precise with my request definitions, but would also see reusing ConnectionSchema as a valid approach.