### PR TITLE
Not found error handling

### DIFF
--- a/connections/app.py
+++ b/connections/app.py
@@ -3,6 +3,7 @@ from http import HTTPStatus
 from flask import Flask, jsonify
 from marshmallow.exceptions import ValidationError
 from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm.exc import NoResultFound
 
 from connections.config import Config
 from connections.extensions import cors, db, ma, migrate
@@ -62,3 +63,9 @@ def register_errorhandlers(app):
     def handle_integrity_errors(error):
         return (jsonify({'description': f'Database integrity error: {error.orig.args[1]}'}),
                 HTTPStatus.BAD_REQUEST)
+
+    @app.errorhandler(NoResultFound)
+    def handle_integrity_errors(error):
+        print(error)
+        return (jsonify({'description': f'Database record not found'}),
+                HTTPStatus.NOT_FOUND)

--- a/connections/app.py
+++ b/connections/app.py
@@ -66,6 +66,5 @@ def register_errorhandlers(app):
 
     @app.errorhandler(NoResultFound)
     def handle_integrity_errors(error):
-        print(error)
         return (jsonify({'description': f'Database record not found'}),
                 HTTPStatus.NOT_FOUND)

--- a/connections/schemas.py
+++ b/connections/schemas.py
@@ -28,10 +28,3 @@ class ConnectionSchema(BaseModelSchema):
 
     class Meta:
         model = Connection
-
-
-class UpdateConnectionTypeSchema(BaseModelSchema):
-    connection_type = EnumField(ConnectionType)
-
-    class Meta:
-        model = Connection

--- a/connections/views.py
+++ b/connections/views.py
@@ -21,13 +21,10 @@ def get_people():
 @blueprint.route('/people/<person_id>/mutual_friends', methods=['GET'])
 @use_args({'target_id': fields.Integer(required=True)})
 def get_mutual_friends(args, person_id):
+    personA = Person.query.filter(Person.id == person_id).one()
+    personB = Person.query.filter(Person.id == args['target_id']).one()
+
     people_schema = PersonSchema(many=True)
-    personA = Person.query.get(person_id)
-    personB = Person.query.get(args['target_id'])
-
-    if not personA or not personB:
-        abort(404)
-
     return people_schema.jsonify(personA.mutual_friends(personB)), HTTPStatus.OK
 
 
@@ -55,9 +52,6 @@ def create_connection(connection):
 @blueprint.route('/connections/<connection_id>', methods=['PATCH'])
 @use_args(UpdateConnectionTypeSchema(), locations=('json',))
 def update_connection_type(request, connection_id):
-    connection = Connection.query.get(connection_id)
-    if not connection:
-        abort(404)
-
+    connection = Connection.query.filter(Connection.id == connection_id).one()
     connection.connection_type = request.connection_type
     return UpdateConnectionTypeSchema().jsonify(connection), HTTPStatus.OK

--- a/connections/views.py
+++ b/connections/views.py
@@ -6,16 +6,15 @@ from webargs.flaskparser import use_args
 
 from connections.models.person import Person
 from connections.models.connection import Connection
-from connections.schemas import ConnectionSchema, UpdateConnectionTypeSchema, PersonSchema
+from connections.schemas import ConnectionSchema, PersonSchema
 
 blueprint = Blueprint('connections', __name__)
 
 
 @blueprint.route('/people', methods=['GET'])
 def get_people():
-    people_schema = PersonSchema(many=True)
     people = Person.query.all()
-    return people_schema.jsonify(people), HTTPStatus.OK
+    return PersonSchema(many=True).jsonify(people), HTTPStatus.OK
 
 
 @blueprint.route('/people/<person_id>/mutual_friends', methods=['GET'])
@@ -23,9 +22,7 @@ def get_people():
 def get_mutual_friends(args, person_id):
     personA = Person.query.filter(Person.id == person_id).one()
     personB = Person.query.filter(Person.id == args['target_id']).one()
-
-    people_schema = PersonSchema(many=True)
-    return people_schema.jsonify(personA.mutual_friends(personB)), HTTPStatus.OK
+    return PersonSchema(many=True).jsonify(personA.mutual_friends(personB)), HTTPStatus.OK
 
 
 @blueprint.route('/people', methods=['POST'])
@@ -37,9 +34,8 @@ def create_person(person):
 
 @blueprint.route('/connections', methods=['GET'])
 def get_connections():
-    connection_schema = ConnectionSchema(many=True)
     connections = Connection.query.all()
-    return connection_schema.jsonify(connections), HTTPStatus.OK
+    return ConnectionSchema(many=True).jsonify(connections), HTTPStatus.OK
 
 
 @blueprint.route('/connections', methods=['POST'])
@@ -50,8 +46,8 @@ def create_connection(connection):
 
 
 @blueprint.route('/connections/<connection_id>', methods=['PATCH'])
-@use_args(UpdateConnectionTypeSchema(), locations=('json',))
+@use_args(ConnectionSchema(), locations=('json',))
 def update_connection_type(request, connection_id):
     connection = Connection.query.filter(Connection.id == connection_id).one()
     connection.connection_type = request.connection_type
-    return UpdateConnectionTypeSchema().jsonify(connection), HTTPStatus.OK
+    return ConnectionSchema().jsonify(connection), HTTPStatus.OK


### PR DESCRIPTION
- Add generic handler for NoResultFound exceptions
- Refactored views: quick tidy, also fetching single records via `.one()` which throws NoResultFound exception